### PR TITLE
[RCS-398] - Increasing threads and memory settings

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 # Add `java -jar /wiremock-standalone.jar` as command if needed
 if [ "${1:0:1}" = "-" ]; then
-	set -- java -Xms2048m -Xmx4096m -Dlog4j.configurationFile="/var/wiremock/lib/log4j2.xml" \
+	set -- java -Xms2048m -Xmx3072m -Dlog4j.configurationFile="/var/wiremock/lib/log4j2.xml" \
 	-cp /var/wiremock/lib/*:/var/wiremock/extensions/* \
 	com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \
 	--extensions com.ninecookies.wiremock.extensions.JsonBodyTransformer,com.ninecookies.wiremock.extensions.CallbackSimulator \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -13,10 +13,11 @@ fi
 
 # Add `java -jar /wiremock-standalone.jar` as command if needed
 if [ "${1:0:1}" = "-" ]; then
-	set -- java -Dlog4j.configurationFile="/var/wiremock/lib/log4j2.xml" \
+	set -- java -Xms2048m -Xmx4096m -Dlog4j.configurationFile="/var/wiremock/lib/log4j2.xml" \
 	-cp /var/wiremock/lib/*:/var/wiremock/extensions/* \
 	com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \
 	--extensions com.ninecookies.wiremock.extensions.JsonBodyTransformer,com.ninecookies.wiremock.extensions.CallbackSimulator \
+	--container-threads 400 \
 	"$@"
 fi
 


### PR DESCRIPTION
These adjustments were used on the CRS heartbeats load testing. 

We had to increase the number of threads because, by default, Wiremock will use only 10 threads. Memory settings were also increased to support the new thread number.