### PR TITLE
Introduced request time matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ Author: - M.Scheepers
 
 ### Features
 - added `$(!OffsetDateTime)` keyword with similar semantics as `$(!Instant)` keyword.
+- added `RequestTimeMatcher` extension that provides regular expression matching against UTC request time.
 
 ### Improvements
 - added support for custom `X-Rps-TraceId` header to callback definitions.
 - callback-simulator now persists callback definitions in the file system to reduce memory footprint of scheduled callbacks for load test scenarios to avoid OOM errors.   
 - added ability to configure callback-simulator's thread pool size using `SCHEDULED_THREAD_POOL_SIZE` environment variable so that it doesn't become a bottle neck in load test scenarios.  
-
 
 ### Fixes
 - none

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ You can find further information in the [documentation](json-body-transformer.md
 It implements WireMock's `PostServeAction` and is an extension that is able to emit POST requests to arbitrary URLs. It allows your WireMock callback to be dynamically depending on the JSON request and response bodies of the related request.
 You can find further information in the [documentation](callback-simulator.md).
 
+## The Request Time Matcher
+It implements Wiremock's `RequestMatcher` and is an extension that is able to match a RegEx pattern against the time of the request in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format as UTC.
+You can find further information in the [documentation](request-time-matcher.md).
+
+
 ### Maven usage
 
 This extension is not hosted on Maven central but on github. To use this artifact add the following repository definition either to your maven `settings.xml` or to the `pom.xml` file of your project that makes use of WireMock.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,7 +16,7 @@ if [ "${1:0:1}" = "-" ]; then
 	set -- java -Dlog4j.configurationFile="/var/wiremock/lib/log4j2.xml" \
 	-cp /var/wiremock/lib/*:/var/wiremock/extensions/* \
 	com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \
-	--extensions com.ninecookies.wiremock.extensions.JsonBodyTransformer,com.ninecookies.wiremock.extensions.CallbackSimulator \
+	--extensions com.ninecookies.wiremock.extensions.JsonBodyTransformer,com.ninecookies.wiremock.extensions.CallbackSimulator,com.ninecookies.wiremock.extensions.RequestTimeMatcher \
 	"$@"
 fi
 

--- a/json-body-transformer.md
+++ b/json-body-transformer.md
@@ -1,5 +1,5 @@
 
-# JSON Body Transformer Project
+# JSON Body Transformer
 
 ### Request value referencing
 

--- a/request-time-matcher.md
+++ b/request-time-matcher.md
@@ -6,7 +6,7 @@ The `request-time-matcher` extension provides the ability to match the time of t
 
 This comes in handy to simulate e.g. short down times / outages of services during load tests.
 
-Imagine a JSON mapping that service a callback URL which only ever returns 204
+Imagine a JSON mapping that serves a callback URL which only ever returns 204
 
 ```java
 stubFor(post(urlEqualTo("3rd/party/url")).willReturn(aResponse().withStatus(204);

--- a/request-time-matcher.md
+++ b/request-time-matcher.md
@@ -1,0 +1,51 @@
+# Request Time Matcher
+
+### Request time matching
+
+The `request-time-matcher` extension provides the ability to match the time of the request against a provided regular expression.
+
+This comes in handy to simulate e.g. short down times / outages of services during load tests.
+
+Imagine a JSON mapping that service a callback URL which only ever returns 204
+
+```java
+stubFor(post(urlEqualTo("3rd/party/url")).willReturn(aResponse().withStatus(204);
+```
+Similar in JSON
+```JSON
+{
+    "request": {
+        "method": "POST",
+        "url": "3rd/party/url"
+    },
+    "response": {
+        "status": 204
+    }
+}
+```
+
+If requests to that very URL should fail for a certain amount of time during a load test to see how the calling service behaves and potentially recovers in such situations this matcher can be used provide an additional stubbing to serve a different response for the same URL at a higher priority as the default (5 - see [stubbing](http://wiremock.org/docs/stubbing/)) as shown in the example below where the HTTP Status 500 will be returned for 10 minutes between 10 and 19:59:59 every hour.
+
+```java
+stubFor(post(urlEqualTo("3rd/party/url")).atPriority(3)
+    .andMatching("request-time-matcher", Parameters.one("pattern", ".*T\\d{2}:1\\d{1}:\\d{2}\\..*"))
+    .willReturn(aResponse().withStatus(500);
+```
+Similar in JSON
+```JSON
+{
+    "request": {
+        "method": "POST",
+        "url": "3rd/party/url"
+    },
+    "customMatcher" : {
+      "name" : "request-time-matcher",
+      "parameters" : {
+        "pattern" : ".*T\\d{2}:1\\d{1}:\\d{2}\\..*"
+      }
+    },
+    "response": {
+        "status": 500
+    }
+}
+```

--- a/request-time-matcher.md
+++ b/request-time-matcher.md
@@ -24,7 +24,7 @@ Similar in JSON
 }
 ```
 
-If requests to that very URL should fail for a certain amount of time during a load test to see how the calling service behaves and potentially recovers in such situations this matcher can be used provide an additional stubbing to serve a different response for the same URL at a higher priority as the default (5 - see [stubbing](http://wiremock.org/docs/stubbing/)) as shown in the example below where the HTTP Status 500 will be returned for 10 minutes between 10 and 19:59:59 every hour.
+If requests to that very URL should fail for a certain amount of time during a load test to see how the calling service behaves and potentially recovers in such situations, this matcher can be used provide an additional stubbing to serve a different response for the same URL at a higher priority as the default (5 - see [stubbing](http://wiremock.org/docs/stubbing/)) as shown in the example below where the HTTP Status 500 will be returned for 10 minutes between 10 and 19:59:59 every hour.
 
 ```java
 stubFor(post(urlEqualTo("3rd/party/url")).atPriority(3)

--- a/src/main/java/com/ninecookies/wiremock/extensions/RequestTimeMatcher.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/RequestTimeMatcher.java
@@ -25,6 +25,9 @@ public class RequestTimeMatcher extends RequestMatcherExtension {
 
     @Override
     public MatchResult match(Request request, Parameters parameters) {
+        if (!parameters.containsKey("pattern")) {
+            return MatchResult.of(false);
+        }
         String pattern = parameters.getString("pattern");
         if (Strings.isNullOrEmpty(pattern)) {
             return MatchResult.of(false);

--- a/src/main/java/com/ninecookies/wiremock/extensions/RequestTimeMatcher.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/RequestTimeMatcher.java
@@ -1,0 +1,34 @@
+package com.ninecookies.wiremock.extensions;
+
+import java.time.Instant;
+import java.util.regex.Pattern;
+
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
+import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
+import com.ninecookies.wiremock.extensions.util.Strings;
+
+/**
+ * Extends the {@link RequestMatcherExtension} and provides the ability to match the UTC request time against a provided
+ * regular expression.
+ *
+ * @author M.Scheepers
+ * @since 0.0.7
+ */
+public class RequestTimeMatcher extends RequestMatcherExtension {
+
+    @Override
+    public String getName() {
+        return "request-time-matcher";
+    }
+
+    @Override
+    public MatchResult match(Request request, Parameters parameters) {
+        String pattern = parameters.getString("pattern");
+        if (Strings.isNullOrEmpty(pattern)) {
+            return MatchResult.of(false);
+        }
+        return MatchResult.of((Pattern.matches(pattern, Instant.now().toString())));
+    }
+}

--- a/src/test/java/com/ninecookies/wiremock/extensions/AbstractExtensionTest.java
+++ b/src/test/java/com/ninecookies/wiremock/extensions/AbstractExtensionTest.java
@@ -1,0 +1,38 @@
+package com.ninecookies.wiremock.extensions;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.jayway.restassured.RestAssured;
+
+public class AbstractExtensionTest {
+
+    private static final int SERVER_PORT = 9090;
+    private WireMockServer wireMockServer;
+
+    @BeforeClass
+    public void beforeClass() {
+        System.out.println("beforeClass()");
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
+        System.setProperty("org.slf4j.simpleLogger.log.com.ninecookies.wiremock.extensions", "debug");
+
+        wireMockServer = new WireMockServer(wireMockConfig()
+                .port(SERVER_PORT)
+                .extensions(new CallbackSimulator(), new JsonBodyTransformer(), new RequestTimeMatcher()));
+        wireMockServer.start();
+
+        RestAssured.port = SERVER_PORT;
+
+        WireMock.configureFor(SERVER_PORT);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void afterClass() {
+        wireMockServer.stop();
+        System.out.println("afterClass()");
+    }
+}

--- a/src/test/java/com/ninecookies/wiremock/extensions/RequestTimeMatcherTest.java
+++ b/src/test/java/com/ninecookies/wiremock/extensions/RequestTimeMatcherTest.java
@@ -68,4 +68,42 @@ public class RequestTimeMatcherTest extends AbstractExtensionTest {
                 .willReturn(aResponse().withStatus(200)));
         when().get(URL).then().statusCode(400);
     }
+
+    @Test
+    public void testRequestTimeMatcherEmptyParamsDoesNotMatch() {
+        stubFor(any(urlEqualTo(URL))
+                .atPriority(3)
+                .andMatching("request-time-matcher", Parameters.empty())
+                .willReturn(aResponse().withStatus(200)));
+        when().get(URL).then().statusCode(400);
+    }
+
+    @Test
+    public void testRequestTimeMatcherEmptyValueDoesNotMatch() {
+        stubFor(any(urlEqualTo(URL))
+                .atPriority(3)
+                .andMatching("request-time-matcher", Parameters.one("pattern", ""))
+                .willReturn(aResponse().withStatus(200)));
+        when().get(URL).then().statusCode(400);
+    }
+
+    @Test
+    public void testRequestTimeMatcherNullValueDoesNotMatch() {
+        Parameters parameters = new Parameters();
+        parameters.put("pattern", null);
+        stubFor(any(urlEqualTo(URL))
+                .atPriority(3)
+                .andMatching("request-time-matcher", parameters)
+                .willReturn(aResponse().withStatus(200)));
+        when().get(URL).then().statusCode(400);
+    }
+
+    @Test
+    public void testRequestTimeMatcherArbitraryValueDoesNotMatch() {
+        stubFor(any(urlEqualTo(URL))
+                .atPriority(3)
+                .andMatching("request-time-matcher", Parameters.one("pattern", "does-not-match"))
+                .willReturn(aResponse().withStatus(200)));
+        when().get(URL).then().statusCode(400);
+    }
 }

--- a/src/test/java/com/ninecookies/wiremock/extensions/RequestTimeMatcherTest.java
+++ b/src/test/java/com/ninecookies/wiremock/extensions/RequestTimeMatcherTest.java
@@ -1,0 +1,71 @@
+package com.ninecookies.wiremock.extensions;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.reset;
+import static com.github.tomakehurst.wiremock.client.WireMock.resetAllRequests;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.jayway.restassured.RestAssured.when;
+
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.Instant;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.github.tomakehurst.wiremock.extension.Parameters;
+
+public class RequestTimeMatcherTest extends AbstractExtensionTest {
+
+    private static final String URL = "/request/match/time";
+
+    @BeforeMethod
+    public void beforeMethod() {
+        // reset mappings
+        reset();
+        // reset requests
+        resetAllRequests();
+
+        // by default return 400 Bad request for the request URL
+        stubFor(any(urlEqualTo(URL))
+                .willReturn(aResponse().withStatus(400)));
+    }
+
+    @Test
+    public void testRequestTimeMatcherMatchesMinute() {
+        String minute = String.valueOf(Instant.now().get(DateTimeFieldType.minuteOfHour()));
+        if (minute.length() > 1) {
+            minute = minute.substring(0, 1);
+        } else {
+            minute = "0";
+        }
+        String pattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:" + minute + "\\d{1}:\\d{2}\\..*";
+        stubFor(any(urlEqualTo(URL))
+                .atPriority(3)
+                .andMatching("request-time-matcher", Parameters.one("pattern", pattern))
+                .willReturn(aResponse().withStatus(200)));
+        when().get(URL).then().statusCode(200);
+    }
+
+    @Test
+    public void testRequestTimeMatcherNotMatchesMinute() {
+        int minute = Instant.now().get(DateTimeFieldType.minuteOfHour());
+        minute += 10;
+        if (minute > 59) {
+            minute = 1;
+        }
+        String sminute = String.valueOf(minute);
+        if (sminute.length() > 1) {
+            sminute = sminute.substring(0, 1);
+        } else {
+            sminute = "0";
+        }
+
+        String pattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:" + sminute + "\\d{1}:\\d{2}\\..*";
+        stubFor(any(urlEqualTo(URL))
+                .atPriority(3)
+                .andMatching("request-time-matcher", Parameters.one("pattern", pattern))
+                .willReturn(aResponse().withStatus(200)));
+        when().get(URL).then().statusCode(400);
+    }
+}


### PR DESCRIPTION
Note: this extension is already part of the latest wiremock docker image with tag `2.26.0-0.0.7-SNAPSHOT` though in order to use for already existing pods one may need to change `imagePullPolicy` to `Always`...