### PR TITLE
maintenance - respect java opts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /home/wiremock
 VOLUME /home/wiremock
 
 EXPOSE 8080 8443
+EXPOSE 7091 7091
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 # Add `java -jar /wiremock-standalone.jar` as command if needed
 if [ "${1:0:1}" = "-" ]; then
-	set -- java -Dlog4j.configurationFile="/var/wiremock/lib/log4j2.xml" \
+	set -- java $JAVA_OPTS -Dlog4j.configurationFile="/var/wiremock/lib/log4j2.xml" \
 	-cp /var/wiremock/lib/*:/var/wiremock/extensions/* \
 	com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \
 	--extensions com.ninecookies.wiremock.extensions.JsonBodyTransformer,com.ninecookies.wiremock.extensions.CallbackSimulator,com.ninecookies.wiremock.extensions.RequestTimeMatcher \


### PR DESCRIPTION
`docker-entrypoint.sh` picks up JAVA_OPTS
docker image exposes port 7091 to be used as JMX and RMI port for remote monitoring purposes