### PR TITLE
support zip files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Author: - none
 - none
 
 ### Improvements
-- none
+- added support for large mapping files (3+ mb) provided as zip file
 
 ### Fixes
 - none

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,6 +10,13 @@ if [ $? -ne 0 ]; then
 	echo "$(ip -4 route show default | cut -d' ' -f3)    host.docker.internal" >> /etc/hosts
 fi
 
+# support for large mapping files provided as zip file
+CURRENT_DIR=$(pwd)
+cd /home/wiremock/mappings
+find . -iname '*.zip' -exec unzip {} \; -exec rm {} \;
+cd /home/wiremock/__files
+find . -iname '*.zip' -exec unzip {} \; -exec rm {} \;
+cd $CURRENT_DIR
 
 # Add `java -jar /wiremock-standalone.jar` as command if needed
 if [ "${1:0:1}" = "-" ]; then


### PR DESCRIPTION
unzip any zip file that is contained in `mappings` and `__files` folder mounted by k8s