### PR TITLE
CHORE implemented callback result verification

### DIFF
--- a/src/main/java/com/ninecookies/wiremock/extensions/AbstractCallbackHandler.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/AbstractCallbackHandler.java
@@ -87,6 +87,8 @@ public abstract class AbstractCallbackHandler<T extends CallbackDefinition> impl
             } else {
                 log.info("publishing of {} will be retried", type.getSimpleName(), e);
             }
+        } catch (Exception e) {
+            log.error("error during callback handling", e);
         } finally {
             if (cleanup) {
                 deleteCallback();

--- a/src/main/java/com/ninecookies/wiremock/extensions/AbstractCallbackHandlerProvider.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/AbstractCallbackHandlerProvider.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.core.Admin;
 import com.ninecookies.wiremock.extensions.api.Callback;
 import com.ninecookies.wiremock.extensions.util.Objects;
 
@@ -69,13 +70,14 @@ public abstract class AbstractCallbackHandlerProvider implements CallbackHandler
      *
      * @param callback the public API {@link Callback} model information.
      * @param placeholders the context for placeholder substitution.
+     * @param admin A wiremock {@link Admin} implementation.
      * @return a concrete implementation of {@link CallbackDefinition}.
      */
-    protected abstract CallbackDefinition convert(Callback callback, Map<String, Object> placeholders);
+    protected abstract CallbackDefinition convert(Callback callback, Map<String, Object> placeholders, Admin admin);
 
     @Override
-    public Runnable get(Callback callback, Map<String, Object> placeholders) {
-        CallbackDefinition callbackDefinition = convert(callback, placeholders);
+    public Runnable get(Callback callback, Map<String, Object> placeholders, Admin admin) {
+        CallbackDefinition callbackDefinition = convert(callback, placeholders, admin);
         if ("null".equals(callbackDefinition.target)) {
             getLog().warn("unresolvable callback target '{}' - ignore {} task with delay '{}' and data '{}'",
                     Objects.coalesce(callback.url, Objects.coalesce(callback.queue, callback.topic)),

--- a/src/main/java/com/ninecookies/wiremock/extensions/CallbackHandlerProvider.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/CallbackHandlerProvider.java
@@ -2,6 +2,7 @@ package com.ninecookies.wiremock.extensions;
 
 import java.util.Map;
 
+import com.github.tomakehurst.wiremock.core.Admin;
 import com.ninecookies.wiremock.extensions.api.Callback;
 
 /**
@@ -25,8 +26,9 @@ public interface CallbackHandlerProvider {
      *
      * @param callback the public API {@link Callback} model information.
      * @param placeholders the context for placeholder substitution.
+     * @param admin A wiremock {@link Admin} implementation.
      * @return the callback handler implementation according to the {@link Callback} or {@code null} if the callback
      *         target (URL, queue, topic) resolution contains a placeholder or keyword that resolved to {@code "null"}.
      */
-    Runnable get(Callback callback, Map<String, Object> placeholders);
+    Runnable get(Callback callback, Map<String, Object> placeholders, Admin admin);
 }

--- a/src/main/java/com/ninecookies/wiremock/extensions/CallbackSimulator.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/CallbackSimulator.java
@@ -1,5 +1,7 @@
 package com.ninecookies.wiremock.extensions;
 
+import static com.ninecookies.wiremock.extensions.util.Objects.coalesce;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -88,10 +90,12 @@ public class CallbackSimulator extends PostServeAction {
                 if (!provider.supports(callback)) {
                     continue;
                 }
-                Runnable handler = provider.get(callback, placeholders);
+                Runnable handler = provider.get(callback, placeholders, admin);
                 if (handler != null) {
                     LOG.info("instance {} - scheduling callback task to: '{}' with delay '{}' and data '{}'",
-                            instance, callback.url, callback.delay, callback.data);
+                            instance,
+                            coalesce(callback.url, coalesce(callback.topic, callback.queue)), callback.delay,
+                            callback.data);
                     executor.schedule(handler, callback.delay, TimeUnit.MILLISECONDS);
                 }
             }

--- a/src/main/java/com/ninecookies/wiremock/extensions/HttpCallbackHandler.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/HttpCallbackHandler.java
@@ -50,17 +50,19 @@ public class HttpCallbackHandler extends AbstractCallbackHandler<HttpCallbackDef
          * The request id to use for the callback.
          */
         public String traceId;
-
         /**
          * The expected HTTP response status for the callback.
          * If omitted all 2xx HTTP status results are considered successful.
          */
         public Integer expectedHttpStatus;
-
         /**
          * Port to record success events for verification purposes.
          */
         public Integer localWiremockPort;
+        /**
+         * Ability to skip callback result reporting if journal is disabled.
+         */
+        public boolean skipResultReport;
     }
 
     private static class HttpStatusRange {
@@ -131,6 +133,11 @@ public class HttpCallbackHandler extends AbstractCallbackHandler<HttpCallbackDef
     }
 
     private void recordSuccess(HttpCallbackDefinition callback, CallbackResponse response) throws CallbackException {
+        if (callback.skipResultReport) {
+            getLog().debug("journal disabled - skip callback result report for '{}'", callback.target);
+            return;
+        }
+
         URI uri = createURI(String.format("http://localhost:%s/callback/result", callback.localWiremockPort));
 
         Map<String, Object> data = mapOf(

--- a/src/main/java/com/ninecookies/wiremock/extensions/HttpCallbackHandler.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/HttpCallbackHandler.java
@@ -1,8 +1,12 @@
 package com.ninecookies.wiremock.extensions;
 
+import static com.ninecookies.wiremock.extensions.util.Maps.entry;
+import static com.ninecookies.wiremock.extensions.util.Maps.mapOf;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.http.HttpEntity;
@@ -27,6 +31,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 
+import com.github.tomakehurst.wiremock.common.Json;
 import com.ninecookies.wiremock.extensions.HttpCallbackHandler.HttpCallbackDefinition;
 import com.ninecookies.wiremock.extensions.api.Authentication;
 
@@ -45,6 +50,50 @@ public class HttpCallbackHandler extends AbstractCallbackHandler<HttpCallbackDef
          * The request id to use for the callback.
          */
         public String traceId;
+
+        /**
+         * The expected HTTP response status for the callback.
+         * If omitted all 2xx HTTP status results are considered successful.
+         */
+        public Integer expectedHttpStatus;
+
+        /**
+         * Port to record success events for verification purposes.
+         */
+        public Integer localWiremockPort;
+    }
+
+    private static class HttpStatusRange {
+        private final int minStatus;
+        private final int maxStatus;
+
+        public HttpStatusRange(Integer expectedStatus) {
+            if (expectedStatus != null) {
+                minStatus = expectedStatus;
+                maxStatus = minStatus + 1;
+            } else {
+                minStatus = 200;
+                maxStatus = 300;
+            }
+        }
+
+        public boolean matches(int status) {
+            return status >= minStatus && status < maxStatus;
+        }
+    }
+
+    private static class CallbackResponse {
+        private String statusLine;
+        private int statusCode;
+        private String entityString;
+
+        private static CallbackResponse of(String statusLine, int statusCode, String entityString) {
+            CallbackResponse response = new CallbackResponse();
+            response.statusLine = statusLine;
+            response.statusCode = statusCode;
+            response.entityString = entityString;
+            return response;
+        }
     }
 
     private static final String RPS_TRACEID_HEADER = "X-Rps-TraceId";
@@ -61,34 +110,72 @@ public class HttpCallbackHandler extends AbstractCallbackHandler<HttpCallbackDef
     @Override
     public void handle(HttpCallbackDefinition callback) throws CallbackException {
         getLog().debug("CallbackHandler.run()");
+
+        URI uri = createURI(callback.target);
+        HttpContext context = createHttpContext(uri, callback.authentication);
+        HttpPost post = createPostRequest(uri, (String) callback.data);
+        post.addHeader(RPS_TRACEID_HEADER, callback.traceId);
+
+        CallbackResponse response = performRequest(post, context);
+
+        HttpStatusRange expectedStatus = new HttpStatusRange(callback.expectedHttpStatus);
+        if (expectedStatus.matches(response.statusCode)) {
+            // in case of success, just print the status line
+            getLog().info("post to '{}' succeeded: response: {}", uri, response.statusLine);
+            recordSuccess(callback, response);
+            return;
+        }
+        throw new RetryCallbackException(String.format(
+                "post to '%s' failed: response: %s\n%s",
+                uri, response.statusLine, response.entityString));
+    }
+
+    private void recordSuccess(HttpCallbackDefinition callback, CallbackResponse response) throws CallbackException {
+        URI uri = createURI(String.format("http://localhost:%s/callback/result", callback.localWiremockPort));
+
+        Map<String, Object> data = mapOf(
+                entry("result", "success"),
+                entry("target", callback.target),
+                entry("response", mapOf(
+                        entry("status", response.statusCode),
+                        entry("body", String.valueOf(response.entityString)))));
+        String bodyData = Json.write(data);
+        HttpPost post = createPostRequest(uri, bodyData);
         try {
-            URI uri = URI.create(callback.target);
-            HttpContext context = createHttpContext(uri, callback.authentication);
-            HttpEntity content = new StringEntity((String) callback.data, ContentType.APPLICATION_JSON);
+            CallbackResponse reportResponse = performRequest(post, null);
+            getLog().debug("report post \n{}\n\tto '{}' succeeded: response: {}",
+                    bodyData, uri, reportResponse.statusLine);
+        } catch (RetryCallbackException e) {
+            throw new CallbackException("unable to record callback success result", e);
+        }
+    }
+
+    private URI createURI(String url) throws CallbackException {
+        try {
+            return URI.create(url);
+        } catch (Exception e) {
+            throw new CallbackException("Unable to create URI of '" + url + "'.", e);
+        }
+    }
+
+    private CallbackResponse performRequest(HttpPost request, HttpContext context) throws RetryCallbackException {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpResponse response = client.execute(request, context);
+            return CallbackResponse.of(response.getStatusLine().toString(),
+                    response.getStatusLine().getStatusCode(),
+                    readEntity(response.getEntity()));
+        } catch (IOException e) {
+            throw new RetryCallbackException(String.format("post to '%s' errored\ncontent %s",
+                    request.getURI(), readEntity(request.getEntity())), e);
+        }
+    }
+
+    private HttpPost createPostRequest(URI uri, String body) throws CallbackException {
+        try {
             HttpPost post = new HttpPost(uri);
             post.setConfig(REQUEST_CONFIG);
-            post.addHeader(RPS_TRACEID_HEADER, callback.traceId);
-            post.setEntity(content);
-
-            try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
-                HttpResponse response = client.execute(post, context);
-                int status = response.getStatusLine().getStatusCode();
-                if (status >= 200 && status < 300) {
-                    // in case of success, just print the status line
-                    getLog().info("post to '{}' succeeded: response: {}", uri, response.getStatusLine());
-                } else {
-                    throw new RetryCallbackException(String.format(
-                            "post to '%s' failed: response: %s\n%s",
-                            uri, response.getStatusLine(), readEntity(response.getEntity())));
-                }
-            } catch (RetryCallbackException e) {
-                throw e;
-            } catch (Exception e) {
-                throw new RetryCallbackException(String.format("post to '%s' errored\ncontent %s",
-                        uri, readEntity(content)), e);
-            }
-        } catch (RetryCallbackException e) {
-            throw e;
+            post.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+            return post;
         } catch (Exception e) {
             throw new CallbackException("unable to create http post", e);
         }
@@ -106,7 +193,7 @@ public class HttpCallbackHandler extends AbstractCallbackHandler<HttpCallbackDef
         return result;
     }
 
-    private HttpContext createHttpContext(URI uri, Authentication authentication) {
+    private HttpContext createHttpContext(URI uri, Authentication authentication) throws CallbackException {
         if (authentication == null) {
             return null;
         }
@@ -119,7 +206,7 @@ public class HttpCallbackHandler extends AbstractCallbackHandler<HttpCallbackDef
                         authentication.getUsername(), authentication.getPassword()));
                 break;
             default:
-                throw new IllegalStateException("Unsupported type '" + authentication.getType() + "'");
+                throw new CallbackException("Unsupported authentication type '" + authentication.getType() + "'");
         }
         HttpHost host = URIUtils.extractHost(uri);
         AuthCache authCache = new BasicAuthCache();

--- a/src/main/java/com/ninecookies/wiremock/extensions/HttpCallbackHandlerProvider.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/HttpCallbackHandlerProvider.java
@@ -37,11 +37,12 @@ public class HttpCallbackHandlerProvider extends AbstractCallbackHandlerProvider
     @Override
     protected HttpCallbackDefinition convert(Callback callback, Map<String, Object> placeholders, Admin admin) {
         HttpCallbackDefinition callbackDefinition = new HttpCallbackDefinition();
+        callbackDefinition.localWiremockPort = admin.getOptions().portNumber();
+        callbackDefinition.skipResultReport = admin.getOptions().requestJournalDisabled();
         callbackDefinition.expectedHttpStatus = callback.expectedHttpStatus;
         callbackDefinition.delay = callback.delay;
         callbackDefinition.target = Placeholders.transformValue(placeholders, callback.url, true);
         callbackDefinition.data = Placeholders.transformJson(placeholders, Json.write(callback.data));
-        callbackDefinition.localWiremockPort = admin.getOptions().portNumber();
         if (callback.authentication != null) {
             callbackDefinition.authentication = Authentication.of(
                     Placeholders.transformValue(callback.authentication.getUsername()),

--- a/src/main/java/com/ninecookies/wiremock/extensions/HttpCallbackHandlerProvider.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/HttpCallbackHandlerProvider.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.core.Admin;
 import com.ninecookies.wiremock.extensions.HttpCallbackHandler.HttpCallbackDefinition;
 import com.ninecookies.wiremock.extensions.api.Authentication;
 import com.ninecookies.wiremock.extensions.api.Callback;
@@ -34,11 +35,13 @@ public class HttpCallbackHandlerProvider extends AbstractCallbackHandlerProvider
     }
 
     @Override
-    protected HttpCallbackDefinition convert(Callback callback, Map<String, Object> placeholders) {
+    protected HttpCallbackDefinition convert(Callback callback, Map<String, Object> placeholders, Admin admin) {
         HttpCallbackDefinition callbackDefinition = new HttpCallbackDefinition();
-        callbackDefinition.target = Placeholders.transformValue(placeholders, callback.url, true);
+        callbackDefinition.expectedHttpStatus = callback.expectedHttpStatus;
         callbackDefinition.delay = callback.delay;
+        callbackDefinition.target = Placeholders.transformValue(placeholders, callback.url, true);
         callbackDefinition.data = Placeholders.transformJson(placeholders, Json.write(callback.data));
+        callbackDefinition.localWiremockPort = admin.getOptions().portNumber();
         if (callback.authentication != null) {
             callbackDefinition.authentication = Authentication.of(
                     Placeholders.transformValue(callback.authentication.getUsername()),

--- a/src/main/java/com/ninecookies/wiremock/extensions/SnsCallbackHandlerProvider.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/SnsCallbackHandlerProvider.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.core.Admin;
 import com.ninecookies.wiremock.extensions.api.Callback;
 import com.ninecookies.wiremock.extensions.util.Placeholders;
 import com.ninecookies.wiremock.extensions.util.Strings;
@@ -35,7 +36,7 @@ public class SnsCallbackHandlerProvider extends AbstractCallbackHandlerProvider 
     }
 
     @Override
-    protected CallbackDefinition convert(Callback callback, Map<String, Object> placeholders) {
+    protected CallbackDefinition convert(Callback callback, Map<String, Object> placeholders, Admin admin) {
         CallbackDefinition callbackDefinition = new CallbackDefinition();
         callbackDefinition.target = Placeholders.transformValue(placeholders, callback.topic, false);
         callbackDefinition.delay = callback.delay;

--- a/src/main/java/com/ninecookies/wiremock/extensions/SqsCallbackHandlerProvider.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/SqsCallbackHandlerProvider.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.core.Admin;
 import com.ninecookies.wiremock.extensions.api.Callback;
 import com.ninecookies.wiremock.extensions.util.Placeholders;
 import com.ninecookies.wiremock.extensions.util.Strings;
@@ -36,7 +37,7 @@ public class SqsCallbackHandlerProvider extends AbstractCallbackHandlerProvider 
     }
 
     @Override
-    protected CallbackDefinition convert(Callback callback, Map<String, Object> placeholders) {
+    protected CallbackDefinition convert(Callback callback, Map<String, Object> placeholders, Admin admin) {
         CallbackDefinition callbackDefinition = new CallbackDefinition();
         callbackDefinition.target = Placeholders.transformValue(placeholders, callback.queue, false);
         callbackDefinition.delay = callback.delay;

--- a/src/main/java/com/ninecookies/wiremock/extensions/api/Callback.java
+++ b/src/main/java/com/ninecookies/wiremock/extensions/api/Callback.java
@@ -41,6 +41,11 @@ public class Callback {
      * The JSON object representing arbitrary callback data.
      */
     public Object data;
+    /**
+     * The expected HTTP response status for the callback.
+     * If omitted all 2xx HTTP status results are considered successful.
+     */
+    public Integer expectedHttpStatus;
 
     /**
      * Create a new instance for an SQS message {@link Callback} definition.
@@ -112,11 +117,29 @@ public class Callback {
      * @return a new {@link Callback} instance ready to use.
      */
     public static Callback of(int delay, String url, String username, String password, String traceId, Object data) {
+        return of(delay, url, username, password, traceId, data, null);
+    }
+
+    /**
+     * Creates a new instance for a {@link Callback} definition with Basic authentication.
+     *
+     * @param delay the period of time in milliseconds to wait before the callback data is POSTed.
+     * @param url the destination URL for the callback's POST data.
+     * @param username the user name for the callback authentication.
+     * @param password the password for the callback authentication.
+     * @param traceId the trace / request identifier to use for the callback.
+     * @param data an arbitrary JSON object representing the callback data to POST.
+     * @param expectedHttpStatus the expected HTTP status code for the callback POST request (defaults to all 2xx).
+     * @return a new {@link Callback} instance ready to use.
+     */
+    public static Callback of(int delay, String url, String username, String password, String traceId, Object data,
+            Integer expectedHttpStatus) {
         Callback result = new Callback();
         result.delay = delay;
         result.url = url;
         result.data = data;
         result.traceId = traceId;
+        result.expectedHttpStatus = expectedHttpStatus;
         if (!Strings.isNullOrEmpty(username) && !Strings.isNullOrEmpty(password)) {
             result.authentication = Authentication.of(username, password);
         }

--- a/src/main/resources/docker/docker-entrypoint.sh
+++ b/src/main/resources/docker/docker-entrypoint.sh
@@ -10,6 +10,15 @@ if [ $? -ne 0 ]; then
 	echo "$(ip -4 route show default | cut -d' ' -f3)    host.docker.internal" >> /etc/hosts
 fi
 
+# create the callback result mapping with lowest priority by default to avoid 404 on report creation
+# Note: we can't simply put the file to the image as the default mapping folder might
+# be replaced by a volume - anyway ensure the folder exists
+if [ ! -d "mappings" ]; then
+  mkdir "mappings"
+fi
+if [ ! -f "mappings/callback-result.json" ]; then
+  echo '{"priority":10,"request":{"url":"/callback/result","method":"POST"},"response":{"status":204}}' > "mappings/callback-result.json"
+fi
 
 # Add `java -jar /wiremock-standalone.jar` as command if needed
 if [ "${1:0:1}" = "-" ]; then

--- a/src/main/resources/docker/log4j2.xml
+++ b/src/main/resources/docker/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="ERROR" packages="com.vlkan.log4j2.logstash.layout" >
     <Properties>
-        <Property name="logLevel">${sys:wm.logging.level:-${env.WM_LOGGING_LEVEL:-info}}</Property>
+        <Property name="logLevel">${sys:wm.logging.level:-${env.WM_LOGGING_LEVEL:-INFO}}</Property>
     </Properties>
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
@@ -19,7 +19,7 @@
         <Logger name="com.ninecookies.wiremock.extensions" level="${logLevel}" />
         <Logger name="com.amazonaws" level="WARN" />
         <Logger name="com.amazon.sqs" level="WARN" />
-        <Root level="info">
+        <Root level="INFO">
             <AppenderRef ref="console" />
         </Root>
     </Loggers>

--- a/src/test/resources/mappings/callback-result.json
+++ b/src/test/resources/mappings/callback-result.json
@@ -1,0 +1,9 @@
+{
+    "request": {
+        "url": "/callback/result",
+        "method": "POST"
+    },
+    "response": {
+        "status": 204
+    }
+}


### PR DESCRIPTION
This PR provides the ability to verify successful HTTP callback processing utilizing the wire mock journal by reporting successful requests to `/callback/result` mapping.